### PR TITLE
Add method for list_form_fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ people = breeze_api.list_people()
 * `edit_contribution`: Edit an existing contribution.
 * `delete_contribution`: Delete a contribution.
 * `list_form_entries`: Get submitted forms.
+* `list_form_fields`: List the fields in a given form.
 * `list_contributions`: List selected contributions.
 * `list_funds`: List your contribution funds.
 * `list_campaigns`: List pledge campaigns.

--- a/breeze_chms_api/breeze.py
+++ b/breeze_chms_api/breeze.py
@@ -778,6 +778,57 @@ class BreezeApi(object):
                              params={'form_id': form_id,
                                      'details': '1' if details else None})
 
+    def list_form_fields(self, form_id):
+        """
+            List the fields for a given form.
+            :param form_id: The ID of the form
+            :return: The fields that correspond to the numeric form id provided, for example:
+        [
+        {
+            "id":"185",
+            "oid":"1512",
+            "field_id":"45",
+            "profile_section_id":"0",
+            "field_type":"name",
+            "name":"Name",
+            "position":"3",
+            "profile_id":"5877b98301fc2",
+            "created_on":"2022-01-12 09:14:43",
+            "options":[
+            ]
+        },
+        {
+            "id":"186",
+            "oid":"1512",
+            "field_id":"46",
+            "profile_section_id":"0",
+            "field_type":"single_line",
+            "name":"Email",
+            "position":"4",
+            "profile_id":"5877b98301fc2",
+            "created_on":"2022-01-12 09:14:43",
+            "options":[
+            ]
+        },
+        {
+            "id":"187",
+            "oid":"1512",
+            "field_id":"47",
+            "profile_section_id":"0",
+            "field_type":"single_line",
+            "name":"Favorite Color",
+            "position":"5",
+            "profile_id":"5877b98301fc2",
+            "created_on":"2022-01-12 09:14:43",
+            "options":[
+            ]
+        }
+        ]
+        """
+        return self._request(ENDPOINTS.FORMS, command='list_form_fields',
+                             params={'form_id': form_id,
+                                     })
+
     # ------------- Tags
 
     def get_tags(self, folder_id=None):

--- a/tests/breeze_test.py
+++ b/tests/breeze_test.py
@@ -204,7 +204,7 @@ class BreezeApiTestCase(unittest.TestCase):
         self.assertEqual(expect_id, field.get('field_id'))
         self.assertEqual('Church Relationships', field.get('section_spec').get('name'))
         profile = {'details': {expect_id: {'content': 'expected'}}}
-        val_from_name =self.breeze_api.field_value_from_name(
+        val_from_name = self.breeze_api.field_value_from_name(
             'Church Relationship',
             profile)
         self.assertEqual('expected', val_from_name.get('content'))
@@ -274,8 +274,8 @@ class BreezeApiTestCase(unittest.TestCase):
             "field_type": "email",
             "response": "true",
             "details": {
-                 "address": "tony@starkindustries.com",
-                 "is_private": 1
+                "address": "tony@starkindustries.com",
+                "is_private": 1
             }
         }
         self.update_person_test(fields=fields)
@@ -380,7 +380,7 @@ class BreezeApiTestCase(unittest.TestCase):
             'group': 'Group',
             'batch_number': '100',
             'batch_name': 'Batch Name',
-            }
+        }
 
         result = self.breeze_api.add_contribution(**args)
 
@@ -405,7 +405,7 @@ class BreezeApiTestCase(unittest.TestCase):
             'group': 'Group',
             'batch_number': '102',
             'batch_name': 'Batch Name'
-            }
+        }
 
         result = self.breeze_api.edit_contribution(**args)
         self.validate_url(ENDPOINTS.CONTRIBUTIONS, command='edit', expect_params=args)
@@ -414,7 +414,7 @@ class BreezeApiTestCase(unittest.TestCase):
 
     def test_list_contributions(self):
         self.make_api(json.dumps({'success': True,
-                             'payment_id': '555'}))
+                                  'payment_id': '555'}))
         args = {
             'start': '3-1-2014',
             'end': '3-2-2014',
@@ -442,7 +442,7 @@ class BreezeApiTestCase(unittest.TestCase):
     def test_delete_contribution(self):
         payment_id = '12345'
         self.make_api(json.dumps({'success': True,
-                             'payment_id': payment_id}))
+                                  'payment_id': payment_id}))
         args = {'payment_id': payment_id}
         self.assertTrue(self.breeze_api.delete_contribution(**args))
         self.validate_url(ENDPOINTS.CONTRIBUTIONS,
@@ -458,9 +458,9 @@ class BreezeApiTestCase(unittest.TestCase):
                 "created_on": "2022-07-31 20:33:18",
                 "person_id": "10898096",
                 "response": {
-                  "person_id": ""
+                    "person_id": ""
                 }
-              }
+            }
         }]))
         args = {'form_id': 329}
         result = self.breeze_api.list_form_entries(**args)
@@ -468,6 +468,62 @@ class BreezeApiTestCase(unittest.TestCase):
         self.validate_url(ENDPOINTS.FORMS,
                           command='list_form_entries',
                           expect_params=args)
+
+    def test_list_form_fields(self):
+        self.make_api(json.dumps([{
+                'id': '46639570',
+                'oid': '146854',
+                'field_id': '1515006468',
+                'profile_section_id': '0',
+                'field_type': 'name',
+                'name': 'Name',
+                'position': '5',
+                'profile_id': '62d1b3e14e67e',
+                'created_on': '2022-07-15 13:37:21',
+                'options': []
+            },
+            {
+                'id': '46639572',
+                'oid': '146854',
+                'field_id': '1515006469',
+                'profile_section_id': '0',
+                'field_type': 'single_line',
+                'name': 'Email',
+                'position': '6',
+                'profile_id': '62d1b3e14e67e',
+                'created_on': '2022-07-15 13:37:21',
+                'options': []
+            },
+            {
+                'id': '46639574',
+                'oid': '146854',
+                'field_id': '1515006470',
+                'profile_section_id': '0',
+                'field_type': 'single_line',
+                'name': 'Phone',
+                'position': '7',
+                'profile_id': '62d1b3e14e67e',
+                'created_on': '2022-07-15 13:37:21',
+                'options': []
+            },
+            {
+                'id': '46639576',
+                'oid': '146854',
+                'field_id': '1515006471',
+                'profile_section_id': '0',
+                'field_type': 'address',
+                'name': 'Address',
+                'position': '8',
+                'profile_id': '62d1b3e14e67e',
+                'created_on': '2022-07-15 13:37:21',
+                'options': []
+            }]))
+        args = {'form_id': 1}
+        result = self.breeze_api.list_form_fields(**args)
+        self.validate_url(ENDPOINTS.FORMS,
+                          command='list_form_fields',
+                          expect_params=args)
+        self.assertEqual(json.loads(self.response.content), result)
 
     def test_list_funds(self):
         self.make_api(json.dumps([{
@@ -492,7 +548,7 @@ class BreezeApiTestCase(unittest.TestCase):
             "created_on": "2014-09-10 02:19:35"
         }]))
         result = self.breeze_api.list_campaigns()
-        self.assertEqual(json.loads(self.response.content),  result)
+        self.assertEqual(json.loads(self.response.content), result)
         self.validate_url(ENDPOINTS.PLEDGES, command='list_campaigns')
 
     def test_false_response(self):
@@ -545,7 +601,7 @@ class BreezeApiTestCase(unittest.TestCase):
     def test_assign_tag(self):
         self.make_api(json.dumps({
             'success': True,
-             }))
+        }))
         args = {'person_id': 14134, 'tag_id': 1569323}
         result = self.breeze_api.assign_tag(**args)
         self.assertEqual(json.loads(self.response.content), result)


### PR DESCRIPTION
breeze.py was missing a method for the https://app.breezechms.com/api#list_form_fields endpoint.
I added one, following the example of the others here.

This change has not been fully tested. What are the test expectations for a PR here?