### PR TITLE
Add a wrapper and unit test for the remove_form_entry API endpoint.

### DIFF
--- a/breeze_chms_api/breeze.py
+++ b/breeze_chms_api/breeze.py
@@ -767,6 +767,16 @@ class BreezeApi(object):
                              params={'form_id': form_id,
                                      'details': '1' if details else None})
 
+    def remove_form_entry(self, entry_id):
+        """
+        Remove the designated form entry.
+        :param entry_id: The ID of the entry to remove from Breeze.
+        :return: True if successful
+        """
+        return self._request(ENDPOINTS.FORMS, command='remove_form_entry',
+                             params={'entry_id': entry_id})
+
+
     def list_form_fields(self, form_id):
         """
             List the fields for a given form.

--- a/tests/breeze_test.py
+++ b/tests/breeze_test.py
@@ -475,6 +475,16 @@ class BreezeApiTestCase(unittest.TestCase):
                           command='list_form_entries',
                           expect_params=args)
 
+    def test_remove_form_entry(self):
+        ret = True
+        self.make_api(ret)
+        args = {'entry_id': '105928817'}
+        result = self.breeze_api.list_form_entries(**args)
+        self.assertEqual(ret, result)
+        self.validate_url(ENDPOINTS.FORMS,
+                          command='list_form_entries',
+                          expect_params=args)
+
     def test_list_form_fields(self):
         self.make_api(json.dumps([{
                 'id': '46639570',

--- a/tests/breeze_test.py
+++ b/tests/breeze_test.py
@@ -479,10 +479,10 @@ class BreezeApiTestCase(unittest.TestCase):
         ret = True
         self.make_api(ret)
         args = {'entry_id': '105928817'}
-        result = self.breeze_api.list_form_entries(**args)
+        result = self.breeze_api.remove_form_entry(**args)
         self.assertEqual(ret, result)
         self.validate_url(ENDPOINTS.FORMS,
-                          command='list_form_entries',
+                          command='remove_form_entry',
                           expect_params=args)
 
     def test_list_form_fields(self):


### PR DESCRIPTION
Tested in production on 1/18/24 using 'https://newmarketchurch.breezechms.com'.
For correct entry ids, the delete was successful.
For incorrect entry id, received 

BreezeError: (<Response [200]>,)